### PR TITLE
Contrib/limit leecher events

### DIFF
--- a/services/common/__init__.py
+++ b/services/common/__init__.py
@@ -1,1 +1,15 @@
-from .aquarium_services import AquariumServices, connect_to_ayon, register_signals
+from .aquarium_services import (
+    AquariumServices,
+    connect_to_ayon,
+    register_signals,
+    IGNORED_AQ_TOPICS,
+    ALLOWED_AQ_TOPICS,
+)
+
+__all__ = [
+    "AquariumServices",
+    "connect_to_ayon",
+    "register_signals",
+    "IGNORED_AQ_TOPICS",
+    "ALLOWED_AQ_TOPICS",
+]

--- a/services/common/aquarium_services.py
+++ b/services/common/aquarium_services.py
@@ -17,6 +17,26 @@ from ayon_api import (
 
 log = logging.getLogger(__name__)
 
+
+IGNORED_AQ_TOPICS: set = {}
+ALLOWED_AQ_TOPICS: set = {
+    "item.created.Asset",
+    "item.updated.Asset",
+    "item.created.Shot",
+    "item.updated.Shot",
+    "item.created.Sequence",
+    "item.updated.Sequence",
+    "item.created.Episode",
+    "item.updated.Episode",
+    "item.created.Task",
+    "item.updated.Task",
+    "item.created.Project",
+    # "item.updated.Project",
+    "user.assigned",
+    "user.unassigned",
+}
+
+
 def get_service_label() -> str:
     return " ".join([
         str(get_service_addon_name()),

--- a/services/common/aquarium_services.py
+++ b/services/common/aquarium_services.py
@@ -30,7 +30,7 @@ ALLOWED_AQ_TOPICS: set = {
     "item.updated.Episode",
     "item.created.Task",
     "item.updated.Task",
-    "item.created.Project",
+    # "item.created.Project", # prevents double project creation
     # "item.updated.Project",
     "user.assigned",
     "user.unassigned",

--- a/services/common/aquarium_services.py
+++ b/services/common/aquarium_services.py
@@ -38,10 +38,8 @@ ALLOWED_AQ_TOPICS: set = {
 
 
 def get_service_label() -> str:
-    return " ".join([
-        str(get_service_addon_name()),
-        str(get_service_addon_version())
-    ])
+    return " ".join([str(get_service_addon_name()), str(get_service_addon_version())])
+
 
 def connect_to_ayon():
     """Connect to AYON server."""
@@ -62,8 +60,10 @@ def connect_to_ayon():
 
     log.info("Connected to AYON server.")
 
+
 def register_signals(_AQS: "AquariumServices"):
     """Register signals to stop Aquarium services"""
+
     def signal_handler(sig, frame):
         print("Process stop requested. Terminating process.")
         _AQS.stop()
@@ -72,11 +72,13 @@ def register_signals(_AQS: "AquariumServices"):
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
 
+
 class AquariumServices:
     """
     Aquarium services for AYON.
     This class is used by leecher and processor services to limit code repetition.
     """
+
     bot_key: str
     aq = Aquarium()
     listener = None
@@ -113,10 +115,7 @@ class AquariumServices:
         url = aquarium_settings["url"]
         domain = aquarium_settings["domain"]
 
-        secrets_by_name = {
-            secret["name"]: secret["value"]
-            for secret in get_secrets()
-        }
+        secrets_by_name = {secret["name"]: secret["value"] for secret in get_secrets()}
 
         services = aquarium_settings["services"]
         bot_key = services["bot_key"]
@@ -138,7 +137,6 @@ class AquariumServices:
         self.aq.bot(bot_key).signin(bot_secret)
 
         self.bot_key = bot_key
-
 
     def connect(self):
         tb_content = None
@@ -163,9 +161,8 @@ class AquariumServices:
         self.log.error(error_message)
         if tb_content:
             print(tb_content)
-        if (
-            (tb_content is not None and self.session_fail_logged == 2)
-            or (tb_content is None and self.session_fail_logged == 1)
+        if (tb_content is not None and self.session_fail_logged == 2) or (
+            tb_content is None and self.session_fail_logged == 1
         ):
             return
 

--- a/services/common/aquarium_services.py
+++ b/services/common/aquarium_services.py
@@ -31,7 +31,7 @@ ALLOWED_AQ_TOPICS: set = {
     "item.created.Task",
     "item.updated.Task",
     # "item.created.Project", # prevents double project creation
-    # "item.updated.Project",
+    "item.updated.Project",
     "user.assigned",
     "user.unassigned",
 }

--- a/services/leecher/leecher/leecher.py
+++ b/services/leecher/leecher/leecher.py
@@ -28,43 +28,6 @@ def create_event_description(event):
     return "Received {topic} #{_key}".format(topic=event.topic, _key=event._key)
 
 
-def create_event_topic(event) -> Optional[str]:
-    """Returns AYON event topic from Aquarium event topic.
-    Aquarium Examples:
-        user.assigned
-        item.created.Task
-    Output Examples:
-        aq.leech.user.assigned
-        aq.leech.task.created
-    """
-    parts = event.topic.split(".")
-    parts = [p.lower() for p in parts]
-    log.debug(f"{parts = }")
-    supported_items = {
-        "asset",
-        "shot",
-        "sequence",
-        "episode",
-        "task",
-        "user",
-        "project",
-    }
-    cmd, item = None, None
-    for _item in supported_items:
-        if _item in parts:
-            item = _item
-            cmd = parts[1]  #! might not be supported by processor
-            break
-
-    if not all([cmd, item]):
-        return None
-
-    result = ["aq", "leech", item, cmd]
-    result = ".".join(result)
-    log.debug(f"Event topic created {result}")
-    return result
-
-
 def callback(event):
     """Callback function for Aquarium event listener."""
     if event.topic in IGNORED_AQ_TOPICS:
@@ -75,20 +38,16 @@ def callback(event):
         log.warning(f"Event topic not allowed: {event.topic}")
         return
 
-    ay_topic = create_event_topic(event)
-    if not ay_topic:
-        log.warning(f"Can't build ayon topic for: {event.topic}")
-        return
-
     if ayon_api.dispatch_event(
-        ay_topic,
+        "aquarium.leech",
         sender=ayon_api.ServiceContext.service_name,
         event_hash=event._key,
         description=create_event_description(event),
         payload=event.to_dict(),
     ):
-        log.info(f"Created event {ay_topic}")
-    log.warning(f"Failed to create event {ay_topic}")
+        log.info(f"Created event for topic: {event.topic}")
+    else:
+        log.warning(f"Failed to create event for topic: {event.topic}")
 
 
 def main():

--- a/services/leecher/leecher/leecher.py
+++ b/services/leecher/leecher/leecher.py
@@ -31,11 +31,11 @@ def create_event_description(event):
 def callback(event):
     """Callback function for Aquarium event listener."""
     if event.topic in IGNORED_AQ_TOPICS:
-        log.warning(f"Event topic ignored: {event.topic}")
+        log.info(f"Event topic ignored: {event.topic}")
         return
 
     if event.topic not in ALLOWED_AQ_TOPICS:
-        log.warning(f"Event topic not allowed: {event.topic}")
+        log.info(f"Event topic not allowed: {event.topic}")
         return
 
     if ayon_api.dispatch_event(

--- a/services/leecher/leecher/leecher.py
+++ b/services/leecher/leecher/leecher.py
@@ -9,11 +9,16 @@ from typing import Any, Union
 from aquarium import Aquarium
 from aquarium import exceptions
 
-from aquarium_common import AquariumServices, connect_to_ayon, register_signals
+from aquarium_common import (
+    AquariumServices,
+    connect_to_ayon,
+    register_signals,
+    IGNORED_AQ_TOPICS,
+    ALLOWED_AQ_TOPICS,
+)
 
 import ayon_api
 
-IGNORE_TOPICS = {}
 
 log = logging.getLogger(__name__)
 _AQS = AquariumServices()
@@ -24,7 +29,10 @@ def create_event_description(event):
 
 
 def callback(event):
-    if event.topic in IGNORE_TOPICS:
+    """Callback function for Aquarium event listener."""
+    if event.topic in IGNORED_AQ_TOPICS:
+        log.warning(f"Event topic ignored: {event.topic}")
+        return
         return
 
     ayon_api.dispatch_event(

--- a/services/leecher/leecher/leecher.py
+++ b/services/leecher/leecher/leecher.py
@@ -33,6 +33,11 @@ def callback(event):
     if event.topic in IGNORED_AQ_TOPICS:
         log.warning(f"Event topic ignored: {event.topic}")
         return
+
+    if event.topic not in ALLOWED_AQ_TOPICS:
+        log.warning(f"Event topic not allowed: {event.topic}")
+        return
+
         return
 
     ayon_api.dispatch_event(

--- a/services/leecher/leecher/leecher.py
+++ b/services/leecher/leecher/leecher.py
@@ -4,7 +4,7 @@ import signal
 import logging
 import threading
 import traceback
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 from aquarium import Aquarium
 from aquarium import exceptions
@@ -28,6 +28,43 @@ def create_event_description(event):
     return "Received {topic} #{_key}".format(topic=event.topic, _key=event._key)
 
 
+def create_event_topic(event) -> Optional[str]:
+    """Returns AYON event topic from Aquarium event topic.
+    Aquarium Examples:
+        user.assigned
+        item.created.Task
+    Output Examples:
+        aq.leech.user.assigned
+        aq.leech.task.created
+    """
+    parts = event.topic.split(".")
+    parts = [p.lower() for p in parts]
+    log.debug(f"{parts = }")
+    supported_items = {
+        "asset",
+        "shot",
+        "sequence",
+        "episode",
+        "task",
+        "user",
+        "project",
+    }
+    cmd, item = None, None
+    for _item in supported_items:
+        if _item in parts:
+            item = _item
+            cmd = parts[1]  #! might not be supported by processor
+            break
+
+    if not all([cmd, item]):
+        return None
+
+    result = ["aq", "leech", item, cmd]
+    result = ".".join(result)
+    log.debug(f"Event topic created {result}")
+    return result
+
+
 def callback(event):
     """Callback function for Aquarium event listener."""
     if event.topic in IGNORED_AQ_TOPICS:
@@ -38,17 +75,20 @@ def callback(event):
         log.warning(f"Event topic not allowed: {event.topic}")
         return
 
+    ay_topic = create_event_topic(event)
+    if not ay_topic:
+        log.warning(f"Can't build ayon topic for: {event.topic}")
         return
 
-    ayon_api.dispatch_event(
-        "aquarium.leech",
+    if ayon_api.dispatch_event(
+        ay_topic,
         sender=ayon_api.ServiceContext.service_name,
         event_hash=event._key,
-        description="Received {topic} #{_key}".format(topic=event.topic, _key=event._key),
+        description=create_event_description(event),
         payload=event.to_dict(),
-    )
-
-    log.info(f"Event stored {event.topic}")
+    ):
+        log.info(f"Created event {ay_topic}")
+    log.warning(f"Failed to create event {ay_topic}")
 
 
 def main():

--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -167,8 +167,7 @@ class AquariumProcessor():
 
     def set_job_processing(self, job):
         event_id = job["id"]
-        source_id = job["dependsOn"]
-        source_event = get_event(event_id)
+        source_event = get_event(job["dependsOn"])
 
         description = f"Processing {source_event['description']}"
 
@@ -182,7 +181,7 @@ class AquariumProcessor():
     def set_job_finished(self, job):
         event_id = job["id"]
         source_id = job["dependsOn"]
-        source_event = get_event(event_id)
+        source_event = get_event(source_id)
         description = f"Processed {source_event['description']}"
 
         update_event(

--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -11,7 +11,13 @@ from ayon_api import (
     update_event,
 )
 
-from aquarium_common import AquariumServices, connect_to_ayon, register_signals
+from aquarium_common import (
+    AquariumServices,
+    connect_to_ayon,
+    register_signals,
+    IGNORED_AQ_TOPICS,
+    ALLOWED_AQ_TOPICS,
+)
 from .handlers import (
     sequences,
     projects,
@@ -122,7 +128,7 @@ class AquariumProcessor():
         ayonTopic = rawEvent["topic"]
         log.info(f"Processing event: {ayonTopic}")
 
-        if ayonTopic in self._AQS.IGNORE_TOPICS:
+        if ayonTopic in IGNORED_AQ_TOPICS:
             return
 
         # QUESTION: Does the events need to trigger a full patch or a partial one ?


### PR DESCRIPTION
This PR limits the `aquarium.leech` events dispatched by the leecher.

List of supported Aquarium Events:
- `item.created.Asset`
- `item.updated.Asset`
- `item.created.Shot`
- `item.updated.Shot`
- `item.created.Sequence`
- `item.updated.Sequence`
- `item.created.Episode`
- `item.updated.Episode`
- `item.created.Task`
- `item.updated.Task`
- `item.updated.Project`
- `user.assigned`
- `user.unassigned`